### PR TITLE
Exclude local opam directory

### DIFF
--- a/src/Find.ml
+++ b/src/Find.ml
@@ -32,5 +32,5 @@ let find ~accept_file_name ~accept_dir_name root_dir =
 let find_dune_files proj_dir =
   find
     ~accept_file_name:(fun name -> name = "dune")
-    ~accept_dir_name:(fun name -> name <> "_build")
+    ~accept_dir_name:(fun name -> name <> "_build" && name <> "_opam")
     proj_dir


### PR DESCRIPTION
Since the tool is designed to display the dependencies of
a project, it sounds reasonable to exclude the directory
used by an opam local switch (*i.e.* `_opam`).

(note: my actual problem was the tool failing on a `dune`
file using [dune-specific extensions to the sexp format](https://github.com/ocaml/dune/blob/master/test/blackbox-tests/test-cases/dune-ppx-driver-system/driver-tests/dune#L110).)
