### PR TITLE
added optional dependency conf-graphviz

### DIFF
--- a/dune-deps.opam
+++ b/dune-deps.opam
@@ -17,6 +17,10 @@ depends: [
   "sexplib"
 ]
 
+depopts: [
+  "conf-graphviz"
+]
+
 synopsis: "Show dependency graph of a multi-component dune project"
 
 description: """


### PR DESCRIPTION
i.e. still compile if it is not there.
However, if people want to use dune-deps, they probably
want dot to be installed on their system