### PR TITLE
udpate to a recent cmdliner

### DIFF
--- a/dune-deps.opam
+++ b/dune-deps.opam
@@ -11,7 +11,7 @@ build: [
 ]
 
 depends: [
-  "cmdliner" {>= "1.0.0"}
+  "cmdliner" {>= "1.1.0"}
   "dune" {>= "2.1"}
   "ocaml"
   "sexplib"

--- a/src/bin/main.ml
+++ b/src/bin/main.ml
@@ -161,15 +161,15 @@ let man = [
 
 let parse_command_line () =
   let info =
-    Term.info
+    Cmd.info
       ~doc
       ~man
       "dune-deps"
   in
-  match Term.eval (cmdline_term, info) with
-  | `Error _ -> exit 1
-  | `Version | `Help -> exit 0
-  | `Ok config -> config
+  match Cmd.eval_value (Cmd.v info cmdline_term) with
+  | Error _ -> exit 1
+  | Ok (`Version | `Help) -> exit 0
+  | Ok (`Ok config) -> config
 
 let main () =
   Printexc.record_backtrace true;


### PR DESCRIPTION
Cmdliner 1.1 deprecated some parts of the `Term` module in favor of a more recent `Cmd` module, see

https://github.com/dbuenzli/cmdliner/blob/master/CHANGES.md#new-cmd-module-and-deprecation-of-the-term-evaluation-interface

As a consequence, building dune-deps shows the following warning:

```
File "src/bin/main.ml", line 164, characters 4-13:
164 |     Term.info
          ^^^^^^^^^
Alert deprecated: Cmdliner.Term.info
Use Cmd.info instead.
File "src/bin/main.ml", line 169, characters 8-17:
169 |   match Term.eval (cmdline_term, info) with
              ^^^^^^^^^
Alert deprecated: Cmdliner.Term.eval
Use Cmd.v and one of Cmd.eval* instead.
```

This PR updates to the recommended 1.1.0 API. Unfortunately, as a result, the new code does not work with Cmdliner 1.0.x anymore. I updated the opam dependencies to reflect this.
