### PR TITLE
Track all names (public and not)

### DIFF
--- a/dune-deps.opam
+++ b/dune-deps.opam
@@ -15,6 +15,7 @@ depends: [
   "dune" {>= "2.1"}
   "ocaml"
   "sexplib"
+  "alcotest" {with-test}
 ]
 
 depopts: [

--- a/dune-deps.opam
+++ b/dune-deps.opam
@@ -7,7 +7,16 @@ dev-repo: "git+https://github.com/mjambon/dune-deps.git"
 license: "BSD-3-Clause"
 
 build: [
-  ["dune" "build" "-p" name "-j" jobs]
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+  ]
 ]
 
 depends: [

--- a/src/lib/Dep_graph.ml
+++ b/src/lib/Dep_graph.ml
@@ -124,11 +124,11 @@ let extract_missing_deps tbl =
 (*
    Add unknown dependencies as nodes representing external libraries.
 *)
-let add_missing_nodes tbl =
+let add_missing_nodes public_private tbl =
   let missing_deps = extract_missing_deps tbl in
   List.iter (fun (dep_name, loc) ->
     let name = Name.Lib dep_name in
-    if not (Hashtbl.mem tbl name) then
+    if not (Hashtbl.mem tbl name) && not (Hashtbl.mem public_private dep_name) then
       let node : Node.t = {
         name;
         kind = Ext;
@@ -150,9 +150,9 @@ let add_missing_nodes tbl =
 
    This also checks that there are no duplicate nodes.
 *)
-let fixup nodes =
+let fixup public_private nodes =
   let tbl = Hashtbl.create 100 in
   List.iter (add_node tbl) nodes;
-  add_missing_nodes tbl;
+  add_missing_nodes public_private tbl;
   let nodes = Hashtbl.fold (fun _name node acc -> node :: acc) tbl [] in
   List.sort (fun (a : Node.t) b -> Name.compare a.name b.name) nodes

--- a/src/lib/Dune.ml
+++ b/src/lib/Dune.ml
@@ -56,8 +56,8 @@ let extract_names public_private entry =
         invalid_arg "stanzas has a different number of names and public_names";
       (* https://dune.readthedocs.io/en/latest/reference/dune/executable.html#executables 
          > Moreover, you can use - for executables that shouldn’t be installed. *)
-      List.iter2 (fun p n -> if p <> "-" then Hashtbl.add public_private p n) ps ns;
-      ns
+      List.iter2 (fun n p -> if p <> "-" then Hashtbl.add public_private n p) ns ps;
+      ps
 
 let extract_deps entry =
   match find_list ["libraries"] entry with
@@ -139,5 +139,5 @@ let load_files paths =
   let public_private = Hashtbl.create 16 in
   List.map (load_file public_private) paths
   |> List.flatten
-  |> Dep_graph.fixup
+  |> Dep_graph.fixup public_private
   |> Filterable.of_dep_graph public_private

--- a/src/lib/Dune.ml
+++ b/src/lib/Dune.ml
@@ -33,18 +33,31 @@ let extract_strings sexp_list =
     | List _ -> None
   ) sexp_list
 
-let extract_names entry =
+let extract_names public_private entry =
   let public_names =
     match find_list ["public_names"; "public_name"] entry with
-    | None -> []
-    | Some l -> extract_strings l
+    | None -> None
+    | Some l -> Some (extract_strings l)
   in
   let names =
     match find_list ["names"; "name"] entry with
-    | None -> []
-    | Some l -> extract_strings l
+    | None -> None
+    | Some l -> Some (extract_strings l)
   in
-  List.sort_uniq String.compare (public_names @ names)
+  match public_names, names with
+  | None, None -> []
+  | Some names, None | None, Some names -> names
+  | Some ps, Some ns ->
+      if List.compare_lengths ps ns <> 0 then
+        (* https://dune.readthedocs.io/en/latest/reference/dune/executable.html#executables 
+           > [(public_names <names>)] describes under what name to install each
+           > executable. The list of names must be of the same length as the
+           > list in the [(names ...)] field. *)
+        invalid_arg "stanzas has a different number of names and public_names";
+      (* https://dune.readthedocs.io/en/latest/reference/dune/executable.html#executables 
+         > Moreover, you can use - for executables that shouldn’t be installed. *)
+      List.iter2 (fun p n -> if p <> "-" then Hashtbl.add public_private p n) ps ns;
+      ns
 
 let extract_deps entry =
   match find_list ["libraries"] entry with
@@ -53,14 +66,14 @@ let extract_deps entry =
 
 (* 'get_index' is a function that returns a fresh numeric identifier for the
    source file 'path'. *)
-let read_node path get_index sexp_entry =
+let read_node public_private path get_index sexp_entry =
   match sexp_entry with
   | Atom _ -> []
   | List entry ->
       match extract_node_kind entry with
       | None -> []
       | Some kind ->
-          let names = extract_names entry in
+          let names = extract_names public_private entry in
           let deps = extract_deps entry in
           List.map (fun name_string ->
             let loc = { Dep_graph.Loc.path; index = get_index () } in
@@ -103,7 +116,7 @@ let inline_subdirs orig_sexp_entries =
   )
   |> List.flatten
 
-let load_file path =
+let load_file public_private path =
   let sexp_entries =
     (try Sexplib.Sexp.load_sexps path
      with e ->
@@ -119,11 +132,12 @@ let load_file path =
     incr index;
     !index
   in
-  List.map (read_node path get_index) sexp_entries
+  List.map (read_node public_private path get_index) sexp_entries
   |> List.flatten
 
 let load_files paths =
-  List.map load_file paths
+  let public_private = Hashtbl.create 16 in
+  List.map (load_file public_private) paths
   |> List.flatten
   |> Dep_graph.fixup
-  |> Filterable.of_dep_graph
+  |> Filterable.of_dep_graph public_private

--- a/src/lib/Dune.ml
+++ b/src/lib/Dune.ml
@@ -36,15 +36,15 @@ let extract_strings sexp_list =
 let extract_names entry =
   let public_names =
     match find_list ["public_names"; "public_name"] entry with
-    | None -> None
-    | Some l -> Some (extract_strings l)
+    | None -> []
+    | Some l -> extract_strings l
   in
-  match public_names with
-  | Some names -> names
-  | None ->
-      match find_list ["names"; "name"] entry with
-      | None -> []
-      | Some l -> extract_strings l
+  let names =
+    match find_list ["names"; "name"] entry with
+    | None -> []
+    | Some l -> extract_strings l
+  in
+  List.sort_uniq String.compare (public_names @ names)
 
 let extract_deps entry =
   match find_list ["libraries"] entry with

--- a/src/lib/Filterable.ml
+++ b/src/lib/Filterable.ml
@@ -71,14 +71,18 @@ let remove_dead_edges nodes =
     { node with edges }
   ) nodes
 
-let of_dep_graph nodes : t =
+let of_dep_graph public_private nodes : t =
   let open Dep_graph in
   let get_node_label = prepare_labels nodes in
   List.map (fun node ->
     {
       id = Node.(node.name) |> Name.id;
       label = get_node_label node;
-      edges = List.map (fun name -> Name.id (Name.Lib name)) Node.(node.deps);
+      edges = List.map (fun name ->
+        match Hashtbl.find_opt public_private name with
+        | None -> Name.id (Name.Lib name)
+        | Some name -> Name.id (Name.Lib name)
+        ) Node.(node.deps);
       important = false;
       kind = Node.(node.kind);
     }

--- a/src/lib/Filterable.mli
+++ b/src/lib/Filterable.mli
@@ -19,7 +19,7 @@ type node = private {
 
 (** Ingest a dependency graph. Node IDs must be unique or [Invalid_argument]
     is raised. *)
-val of_dep_graph : Dep_graph.t -> t
+val of_dep_graph : (string, string) Hashtbl.t -> Dep_graph.t -> t
 
 (** Return the graph as a list of nodes.
     Any edge pointing to an undeclared node is discarded. *)

--- a/src/test/dune
+++ b/src/test/dune
@@ -1,4 +1,4 @@
-(executable
+(test
   (name test)
   (libraries dune_deps alcotest)
 )

--- a/test/proj-deps.dot.expected
+++ b/test/proj-deps.dot.expected
@@ -4,17 +4,17 @@ digraph {
   "exe:proj/dune:2" [label="prog3",shape=diamond]
   "lib:ext2" [label="ext2",style=filled]
   "lib:ext3" [label="ext3",style=filled]
-  "lib:lib1" [label="lib1"]
   "lib:lib2" [label="lib2"]
   "lib:lib3" [label="lib3",style=bold]
   "lib:lib4" [label="lib4"]
   "lib:lib5" [label="lib5",style=bold]
-  "exe:proj/dune:0" -> "lib:lib1"
+  "lib:priv_lib1" [label="priv_lib1"]
+  "exe:proj/dune:0" -> "lib:priv_lib1"
   "exe:proj/dune:0" -> "lib:lib2"
   "exe:proj/dune:0" -> "lib:lib3"
-  "exe:proj/dune:1" -> "lib:lib1"
+  "exe:proj/dune:1" -> "lib:priv_lib1"
   "exe:proj/dune:1" -> "lib:lib3"
-  "exe:proj/dune:2" -> "lib:lib1"
+  "exe:proj/dune:2" -> "lib:priv_lib1"
   "exe:proj/dune:2" -> "lib:lib3"
   "lib:lib2" -> "lib:lib4"
   "lib:lib2" -> "lib:lib5"
@@ -22,8 +22,8 @@ digraph {
   "lib:lib3" -> "lib:lib4"
   "lib:lib3" -> "lib:lib5"
   "lib:lib3" -> "lib:ext2"
-  "lib:lib4" -> "lib:lib1"
+  "lib:lib4" -> "lib:priv_lib1"
   "lib:lib4" -> "lib:ext3"
-  "lib:lib5" -> "lib:lib1"
+  "lib:lib5" -> "lib:priv_lib1"
   "lib:lib5" -> "lib:ext3"
 }

--- a/test/proj-deps.dot.expected
+++ b/test/proj-deps.dot.expected
@@ -1,29 +1,29 @@
 digraph {
+  "exe:proj/dune:2" [label="pppppprog3",shape=diamond]
+  "exe:proj/dune:1" [label="pppprog2",shape=diamond]
   "exe:proj/dune:0" [label="prog1",shape=diamond]
-  "exe:proj/dune:1" [label="prog2",shape=diamond]
-  "exe:proj/dune:2" [label="prog3",shape=diamond]
   "lib:ext2" [label="ext2",style=filled]
   "lib:ext3" [label="ext3",style=filled]
+  "lib:lib1" [label="lib1"]
   "lib:lib2" [label="lib2"]
   "lib:lib3" [label="lib3",style=bold]
   "lib:lib4" [label="lib4"]
   "lib:lib5" [label="lib5",style=bold]
-  "lib:priv_lib1" [label="priv_lib1"]
-  "exe:proj/dune:0" -> "lib:priv_lib1"
+  "exe:proj/dune:2" -> "lib:lib1"
+  "exe:proj/dune:2" -> "lib:lib3"
+  "exe:proj/dune:1" -> "lib:lib1"
+  "exe:proj/dune:1" -> "lib:lib3"
+  "exe:proj/dune:0" -> "lib:lib1"
   "exe:proj/dune:0" -> "lib:lib2"
   "exe:proj/dune:0" -> "lib:lib3"
-  "exe:proj/dune:1" -> "lib:priv_lib1"
-  "exe:proj/dune:1" -> "lib:lib3"
-  "exe:proj/dune:2" -> "lib:priv_lib1"
-  "exe:proj/dune:2" -> "lib:lib3"
   "lib:lib2" -> "lib:lib4"
   "lib:lib2" -> "lib:lib5"
   "lib:lib2" -> "lib:ext2"
   "lib:lib3" -> "lib:lib4"
   "lib:lib3" -> "lib:lib5"
   "lib:lib3" -> "lib:ext2"
-  "lib:lib4" -> "lib:priv_lib1"
+  "lib:lib4" -> "lib:lib1"
   "lib:lib4" -> "lib:ext3"
-  "lib:lib5" -> "lib:priv_lib1"
+  "lib:lib5" -> "lib:lib1"
   "lib:lib5" -> "lib:ext3"
 }

--- a/test/proj-hourglass.dot.expected
+++ b/test/proj-hourglass.dot.expected
@@ -4,17 +4,17 @@ digraph {
   "exe:proj/dune:2" [label="prog3",shape=diamond]
   "lib:ext2" [label="ext2",style=filled]
   "lib:ext3" [label="ext3",style=filled]
-  "lib:lib1" [label="lib1"]
   "lib:lib2" [label="lib2"]
   "lib:lib3" [label="lib3",style=bold]
   "lib:lib4" [label="lib4"]
   "lib:lib5" [label="lib5",style=bold]
-  "exe:proj/dune:0" -> "lib:lib1"
+  "lib:priv_lib1" [label="priv_lib1"]
+  "exe:proj/dune:0" -> "lib:priv_lib1"
   "exe:proj/dune:0" -> "lib:lib2"
   "exe:proj/dune:0" -> "lib:lib3"
-  "exe:proj/dune:1" -> "lib:lib1"
+  "exe:proj/dune:1" -> "lib:priv_lib1"
   "exe:proj/dune:1" -> "lib:lib3"
-  "exe:proj/dune:2" -> "lib:lib1"
+  "exe:proj/dune:2" -> "lib:priv_lib1"
   "exe:proj/dune:2" -> "lib:lib3"
   "lib:lib2" -> "lib:lib4"
   "lib:lib2" -> "lib:lib5"
@@ -22,8 +22,8 @@ digraph {
   "lib:lib3" -> "lib:lib4"
   "lib:lib3" -> "lib:lib5"
   "lib:lib3" -> "lib:ext2"
-  "lib:lib4" -> "lib:lib1"
+  "lib:lib4" -> "lib:priv_lib1"
   "lib:lib4" -> "lib:ext3"
-  "lib:lib5" -> "lib:lib1"
+  "lib:lib5" -> "lib:priv_lib1"
   "lib:lib5" -> "lib:ext3"
 }

--- a/test/proj-hourglass.dot.expected
+++ b/test/proj-hourglass.dot.expected
@@ -1,29 +1,29 @@
 digraph {
+  "exe:proj/dune:2" [label="pppppprog3",shape=diamond]
+  "exe:proj/dune:1" [label="pppprog2",shape=diamond]
   "exe:proj/dune:0" [label="prog1",shape=diamond]
-  "exe:proj/dune:1" [label="prog2",shape=diamond]
-  "exe:proj/dune:2" [label="prog3",shape=diamond]
   "lib:ext2" [label="ext2",style=filled]
   "lib:ext3" [label="ext3",style=filled]
+  "lib:lib1" [label="lib1"]
   "lib:lib2" [label="lib2"]
   "lib:lib3" [label="lib3",style=bold]
   "lib:lib4" [label="lib4"]
   "lib:lib5" [label="lib5",style=bold]
-  "lib:priv_lib1" [label="priv_lib1"]
-  "exe:proj/dune:0" -> "lib:priv_lib1"
+  "exe:proj/dune:2" -> "lib:lib1"
+  "exe:proj/dune:2" -> "lib:lib3"
+  "exe:proj/dune:1" -> "lib:lib1"
+  "exe:proj/dune:1" -> "lib:lib3"
+  "exe:proj/dune:0" -> "lib:lib1"
   "exe:proj/dune:0" -> "lib:lib2"
   "exe:proj/dune:0" -> "lib:lib3"
-  "exe:proj/dune:1" -> "lib:priv_lib1"
-  "exe:proj/dune:1" -> "lib:lib3"
-  "exe:proj/dune:2" -> "lib:priv_lib1"
-  "exe:proj/dune:2" -> "lib:lib3"
   "lib:lib2" -> "lib:lib4"
   "lib:lib2" -> "lib:lib5"
   "lib:lib2" -> "lib:ext2"
   "lib:lib3" -> "lib:lib4"
   "lib:lib3" -> "lib:lib5"
   "lib:lib3" -> "lib:ext2"
-  "lib:lib4" -> "lib:priv_lib1"
+  "lib:lib4" -> "lib:lib1"
   "lib:lib4" -> "lib:ext3"
-  "lib:lib5" -> "lib:priv_lib1"
+  "lib:lib5" -> "lib:lib1"
   "lib:lib5" -> "lib:ext3"
 }

--- a/test/proj-no-exe.dot.expected
+++ b/test/proj-no-exe.dot.expected
@@ -5,7 +5,7 @@ digraph {
   "lib:foosubdirlib" [label="foosubdirlib"]
   "lib:foosubdirlib-dep" [label="foosubdirlib-dep",style=filled]
   "lib:lib-or-exe" [label="lib-or-exe"]
-  "lib:lib1" [label="lib1"]
+  "lib:lib1" [label="lib1",style=filled]
   "lib:lib1-alt" [label="lib1-alt",style=filled]
   "lib:lib2" [label="lib2"]
   "lib:lib3" [label="lib3"]
@@ -20,9 +20,9 @@ digraph {
   "lib:lib3" -> "lib:lib4"
   "lib:lib3" -> "lib:lib5"
   "lib:lib3" -> "lib:ext2"
-  "lib:lib4" -> "lib:lib1"
+  "lib:lib4" -> "lib:priv_lib1"
   "lib:lib4" -> "lib:ext3"
-  "lib:lib5" -> "lib:lib1"
+  "lib:lib5" -> "lib:priv_lib1"
   "lib:lib5" -> "lib:ext3"
-  "lib:more" -> "lib:lib1"
+  "lib:more" -> "lib:priv_lib1"
 }

--- a/test/proj-no-exe.dot.expected
+++ b/test/proj-no-exe.dot.expected
@@ -12,6 +12,7 @@ digraph {
   "lib:lib4" [label="lib4"]
   "lib:lib5" [label="lib5"]
   "lib:more" [label="more"]
+  "lib:priv_lib1" [label="priv_lib1"]
   "lib:foosubdirlib" -> "lib:foosubdirlib-dep"
   "lib:lib2" -> "lib:lib4"
   "lib:lib2" -> "lib:lib5"

--- a/test/proj-no-exe.dot.expected
+++ b/test/proj-no-exe.dot.expected
@@ -5,14 +5,13 @@ digraph {
   "lib:foosubdirlib" [label="foosubdirlib"]
   "lib:foosubdirlib-dep" [label="foosubdirlib-dep",style=filled]
   "lib:lib-or-exe" [label="lib-or-exe"]
-  "lib:lib1" [label="lib1",style=filled]
+  "lib:lib1" [label="lib1"]
   "lib:lib1-alt" [label="lib1-alt",style=filled]
   "lib:lib2" [label="lib2"]
   "lib:lib3" [label="lib3"]
   "lib:lib4" [label="lib4"]
   "lib:lib5" [label="lib5"]
   "lib:more" [label="more"]
-  "lib:priv_lib1" [label="priv_lib1"]
   "lib:foosubdirlib" -> "lib:foosubdirlib-dep"
   "lib:lib2" -> "lib:lib4"
   "lib:lib2" -> "lib:lib5"
@@ -20,9 +19,9 @@ digraph {
   "lib:lib3" -> "lib:lib4"
   "lib:lib3" -> "lib:lib5"
   "lib:lib3" -> "lib:ext2"
-  "lib:lib4" -> "lib:priv_lib1"
+  "lib:lib4" -> "lib:lib1"
   "lib:lib4" -> "lib:ext3"
-  "lib:lib5" -> "lib:priv_lib1"
+  "lib:lib5" -> "lib:lib1"
   "lib:lib5" -> "lib:ext3"
-  "lib:more" -> "lib:priv_lib1"
+  "lib:more" -> "lib:lib1"
 }

--- a/test/proj-no-ext.dot.expected
+++ b/test/proj-no-ext.dot.expected
@@ -1,43 +1,42 @@
 digraph {
   "exe:proj/bar/test/dune:0" [label="test<bar/test>",shape=diamond]
   "exe:proj/foo/test/dune:0" [label="test<foo/test>",shape=diamond]
-  "exe:proj/dune:11" [label="lib-or-exe",shape=diamond]
+  "exe:proj/dune:10" [label="lib-or-exe",shape=diamond]
   "exe:proj/dune:0" [label="prog1",shape=diamond]
   "exe:proj/dune:1" [label="prog2",shape=diamond]
   "exe:proj/dune:2" [label="prog3",shape=diamond]
   "exe:proj/dune:3" [label="prog4",shape=diamond]
+  "exe:proj/dune:11" [label="test<proj>",shape=diamond]
   "exe:proj/dune:12" [label="test<proj>",shape=diamond]
-  "exe:proj/dune:13" [label="test<proj>",shape=diamond]
   "exe:proj/with-subdir/dune:2" [label="barnotsubdir",shape=diamond]
   "exe:proj/with-subdir/dune:0" [label="foosubdir",shape=diamond]
   "lib:foosubdirlib" [label="foosubdirlib"]
   "lib:lib-or-exe" [label="lib-or-exe"]
-  "lib:lib1" [label="lib1"]
   "lib:lib2" [label="lib2"]
   "lib:lib3" [label="lib3"]
   "lib:lib4" [label="lib4"]
   "lib:lib5" [label="lib5"]
   "lib:more" [label="more"]
   "lib:priv_lib1" [label="priv_lib1"]
-  "exe:proj/bar/test/dune:0" -> "lib:lib1"
-  "exe:proj/foo/test/dune:0" -> "lib:lib1"
-  "exe:proj/dune:11" -> "lib:lib-or-exe"
-  "exe:proj/dune:0" -> "lib:lib1"
+  "exe:proj/bar/test/dune:0" -> "lib:priv_lib1"
+  "exe:proj/foo/test/dune:0" -> "lib:priv_lib1"
+  "exe:proj/dune:10" -> "lib:lib-or-exe"
+  "exe:proj/dune:0" -> "lib:priv_lib1"
   "exe:proj/dune:0" -> "lib:lib2"
   "exe:proj/dune:0" -> "lib:lib3"
-  "exe:proj/dune:1" -> "lib:lib1"
+  "exe:proj/dune:1" -> "lib:priv_lib1"
   "exe:proj/dune:1" -> "lib:lib3"
-  "exe:proj/dune:2" -> "lib:lib1"
+  "exe:proj/dune:2" -> "lib:priv_lib1"
   "exe:proj/dune:2" -> "lib:lib3"
   "exe:proj/dune:3" -> "lib:lib4"
-  "exe:proj/dune:12" -> "lib:lib1"
+  "exe:proj/dune:11" -> "lib:priv_lib1"
   "exe:proj/with-subdir/dune:2" -> "lib:foosubdirlib"
   "exe:proj/with-subdir/dune:0" -> "lib:foosubdirlib"
   "lib:lib2" -> "lib:lib4"
   "lib:lib2" -> "lib:lib5"
   "lib:lib3" -> "lib:lib4"
   "lib:lib3" -> "lib:lib5"
-  "lib:lib4" -> "lib:lib1"
-  "lib:lib5" -> "lib:lib1"
-  "lib:more" -> "lib:lib1"
+  "lib:lib4" -> "lib:priv_lib1"
+  "lib:lib5" -> "lib:priv_lib1"
+  "lib:more" -> "lib:priv_lib1"
 }

--- a/test/proj-no-ext.dot.expected
+++ b/test/proj-no-ext.dot.expected
@@ -1,13 +1,13 @@
 digraph {
   "exe:proj/bar/test/dune:0" [label="test<bar/test>",shape=diamond]
   "exe:proj/foo/test/dune:0" [label="test<foo/test>",shape=diamond]
-  "exe:proj/dune:10" [label="lib-or-exe",shape=diamond]
+  "exe:proj/dune:11" [label="lib-or-exe",shape=diamond]
   "exe:proj/dune:0" [label="prog1",shape=diamond]
   "exe:proj/dune:1" [label="prog2",shape=diamond]
   "exe:proj/dune:2" [label="prog3",shape=diamond]
   "exe:proj/dune:3" [label="prog4",shape=diamond]
-  "exe:proj/dune:11" [label="test<proj>",shape=diamond]
   "exe:proj/dune:12" [label="test<proj>",shape=diamond]
+  "exe:proj/dune:13" [label="test<proj>",shape=diamond]
   "exe:proj/with-subdir/dune:2" [label="barnotsubdir",shape=diamond]
   "exe:proj/with-subdir/dune:0" [label="foosubdir",shape=diamond]
   "lib:foosubdirlib" [label="foosubdirlib"]
@@ -18,9 +18,10 @@ digraph {
   "lib:lib4" [label="lib4"]
   "lib:lib5" [label="lib5"]
   "lib:more" [label="more"]
+  "lib:priv_lib1" [label="priv_lib1"]
   "exe:proj/bar/test/dune:0" -> "lib:lib1"
   "exe:proj/foo/test/dune:0" -> "lib:lib1"
-  "exe:proj/dune:10" -> "lib:lib-or-exe"
+  "exe:proj/dune:11" -> "lib:lib-or-exe"
   "exe:proj/dune:0" -> "lib:lib1"
   "exe:proj/dune:0" -> "lib:lib2"
   "exe:proj/dune:0" -> "lib:lib3"
@@ -29,7 +30,7 @@ digraph {
   "exe:proj/dune:2" -> "lib:lib1"
   "exe:proj/dune:2" -> "lib:lib3"
   "exe:proj/dune:3" -> "lib:lib4"
-  "exe:proj/dune:11" -> "lib:lib1"
+  "exe:proj/dune:12" -> "lib:lib1"
   "exe:proj/with-subdir/dune:2" -> "lib:foosubdirlib"
   "exe:proj/with-subdir/dune:0" -> "lib:foosubdirlib"
   "lib:lib2" -> "lib:lib4"

--- a/test/proj-no-ext.dot.expected
+++ b/test/proj-no-ext.dot.expected
@@ -2,9 +2,9 @@ digraph {
   "exe:proj/bar/test/dune:0" [label="test<bar/test>",shape=diamond]
   "exe:proj/foo/test/dune:0" [label="test<foo/test>",shape=diamond]
   "exe:proj/dune:10" [label="lib-or-exe",shape=diamond]
+  "exe:proj/dune:2" [label="pppppprog3",shape=diamond]
+  "exe:proj/dune:1" [label="pppprog2",shape=diamond]
   "exe:proj/dune:0" [label="prog1",shape=diamond]
-  "exe:proj/dune:1" [label="prog2",shape=diamond]
-  "exe:proj/dune:2" [label="prog3",shape=diamond]
   "exe:proj/dune:3" [label="prog4",shape=diamond]
   "exe:proj/dune:11" [label="test<proj>",shape=diamond]
   "exe:proj/dune:12" [label="test<proj>",shape=diamond]
@@ -12,31 +12,31 @@ digraph {
   "exe:proj/with-subdir/dune:0" [label="foosubdir",shape=diamond]
   "lib:foosubdirlib" [label="foosubdirlib"]
   "lib:lib-or-exe" [label="lib-or-exe"]
+  "lib:lib1" [label="lib1"]
   "lib:lib2" [label="lib2"]
   "lib:lib3" [label="lib3"]
   "lib:lib4" [label="lib4"]
   "lib:lib5" [label="lib5"]
   "lib:more" [label="more"]
-  "lib:priv_lib1" [label="priv_lib1"]
-  "exe:proj/bar/test/dune:0" -> "lib:priv_lib1"
-  "exe:proj/foo/test/dune:0" -> "lib:priv_lib1"
+  "exe:proj/bar/test/dune:0" -> "lib:lib1"
+  "exe:proj/foo/test/dune:0" -> "lib:lib1"
   "exe:proj/dune:10" -> "lib:lib-or-exe"
-  "exe:proj/dune:0" -> "lib:priv_lib1"
+  "exe:proj/dune:2" -> "lib:lib1"
+  "exe:proj/dune:2" -> "lib:lib3"
+  "exe:proj/dune:1" -> "lib:lib1"
+  "exe:proj/dune:1" -> "lib:lib3"
+  "exe:proj/dune:0" -> "lib:lib1"
   "exe:proj/dune:0" -> "lib:lib2"
   "exe:proj/dune:0" -> "lib:lib3"
-  "exe:proj/dune:1" -> "lib:priv_lib1"
-  "exe:proj/dune:1" -> "lib:lib3"
-  "exe:proj/dune:2" -> "lib:priv_lib1"
-  "exe:proj/dune:2" -> "lib:lib3"
   "exe:proj/dune:3" -> "lib:lib4"
-  "exe:proj/dune:11" -> "lib:priv_lib1"
+  "exe:proj/dune:11" -> "lib:lib1"
   "exe:proj/with-subdir/dune:2" -> "lib:foosubdirlib"
   "exe:proj/with-subdir/dune:0" -> "lib:foosubdirlib"
   "lib:lib2" -> "lib:lib4"
   "lib:lib2" -> "lib:lib5"
   "lib:lib3" -> "lib:lib4"
   "lib:lib3" -> "lib:lib5"
-  "lib:lib4" -> "lib:priv_lib1"
-  "lib:lib5" -> "lib:priv_lib1"
-  "lib:more" -> "lib:priv_lib1"
+  "lib:lib4" -> "lib:lib1"
+  "lib:lib5" -> "lib:lib1"
+  "lib:more" -> "lib:lib1"
 }

--- a/test/proj.dot.expected
+++ b/test/proj.dot.expected
@@ -2,13 +2,13 @@ digraph {
   "exe:extra-proj/dune:0" [label="extra",shape=diamond]
   "exe:proj/bar/test/dune:0" [label="test<bar/test>",shape=diamond]
   "exe:proj/foo/test/dune:0" [label="test<foo/test>",shape=diamond]
-  "exe:proj/dune:10" [label="lib-or-exe",shape=diamond]
+  "exe:proj/dune:11" [label="lib-or-exe",shape=diamond]
   "exe:proj/dune:0" [label="prog1",shape=diamond]
   "exe:proj/dune:1" [label="prog2",shape=diamond]
   "exe:proj/dune:2" [label="prog3",shape=diamond]
   "exe:proj/dune:3" [label="prog4",shape=diamond]
-  "exe:proj/dune:11" [label="test<proj>",shape=diamond]
   "exe:proj/dune:12" [label="test<proj>",shape=diamond]
+  "exe:proj/dune:13" [label="test<proj>",shape=diamond]
   "exe:proj/with-subdir/dune:2" [label="barnotsubdir",shape=diamond]
   "exe:proj/with-subdir/dune:0" [label="foosubdir",shape=diamond]
   "lib:ext1" [label="ext1",style=filled]
@@ -24,9 +24,10 @@ digraph {
   "lib:lib4" [label="lib4"]
   "lib:lib5" [label="lib5"]
   "lib:more" [label="more"]
+  "lib:priv_lib1" [label="priv_lib1"]
   "exe:proj/bar/test/dune:0" -> "lib:lib1"
   "exe:proj/foo/test/dune:0" -> "lib:lib1"
-  "exe:proj/dune:10" -> "lib:lib-or-exe"
+  "exe:proj/dune:11" -> "lib:lib-or-exe"
   "exe:proj/dune:0" -> "lib:lib1"
   "exe:proj/dune:0" -> "lib:lib2"
   "exe:proj/dune:0" -> "lib:lib3"
@@ -37,8 +38,8 @@ digraph {
   "exe:proj/dune:2" -> "lib:lib3"
   "exe:proj/dune:2" -> "lib:ext1"
   "exe:proj/dune:3" -> "lib:lib4"
-  "exe:proj/dune:11" -> "lib:lib1"
-  "exe:proj/dune:12" -> "lib:lib1-alt"
+  "exe:proj/dune:12" -> "lib:lib1"
+  "exe:proj/dune:13" -> "lib:lib1-alt"
   "exe:proj/with-subdir/dune:2" -> "lib:foosubdirlib"
   "exe:proj/with-subdir/dune:0" -> "lib:foosubdirlib"
   "lib:foosubdirlib" -> "lib:foosubdirlib-dep"

--- a/test/proj.dot.expected
+++ b/test/proj.dot.expected
@@ -3,9 +3,9 @@ digraph {
   "exe:proj/bar/test/dune:0" [label="test<bar/test>",shape=diamond]
   "exe:proj/foo/test/dune:0" [label="test<foo/test>",shape=diamond]
   "exe:proj/dune:10" [label="lib-or-exe",shape=diamond]
+  "exe:proj/dune:2" [label="pppppprog3",shape=diamond]
+  "exe:proj/dune:1" [label="pppprog2",shape=diamond]
   "exe:proj/dune:0" [label="prog1",shape=diamond]
-  "exe:proj/dune:1" [label="prog2",shape=diamond]
-  "exe:proj/dune:2" [label="prog3",shape=diamond]
   "exe:proj/dune:3" [label="prog4",shape=diamond]
   "exe:proj/dune:11" [label="test<proj>",shape=diamond]
   "exe:proj/dune:12" [label="test<proj>",shape=diamond]
@@ -17,28 +17,27 @@ digraph {
   "lib:foosubdirlib" [label="foosubdirlib"]
   "lib:foosubdirlib-dep" [label="foosubdirlib-dep",style=filled]
   "lib:lib-or-exe" [label="lib-or-exe"]
-  "lib:lib1" [label="lib1",style=filled]
+  "lib:lib1" [label="lib1"]
   "lib:lib1-alt" [label="lib1-alt",style=filled]
   "lib:lib2" [label="lib2"]
   "lib:lib3" [label="lib3"]
   "lib:lib4" [label="lib4"]
   "lib:lib5" [label="lib5"]
   "lib:more" [label="more"]
-  "lib:priv_lib1" [label="priv_lib1"]
-  "exe:proj/bar/test/dune:0" -> "lib:priv_lib1"
-  "exe:proj/foo/test/dune:0" -> "lib:priv_lib1"
+  "exe:proj/bar/test/dune:0" -> "lib:lib1"
+  "exe:proj/foo/test/dune:0" -> "lib:lib1"
   "exe:proj/dune:10" -> "lib:lib-or-exe"
-  "exe:proj/dune:0" -> "lib:priv_lib1"
-  "exe:proj/dune:0" -> "lib:lib2"
-  "exe:proj/dune:0" -> "lib:lib3"
-  "exe:proj/dune:1" -> "lib:priv_lib1"
-  "exe:proj/dune:1" -> "lib:lib3"
-  "exe:proj/dune:1" -> "lib:ext1"
-  "exe:proj/dune:2" -> "lib:priv_lib1"
+  "exe:proj/dune:2" -> "lib:lib1"
   "exe:proj/dune:2" -> "lib:lib3"
   "exe:proj/dune:2" -> "lib:ext1"
+  "exe:proj/dune:1" -> "lib:lib1"
+  "exe:proj/dune:1" -> "lib:lib3"
+  "exe:proj/dune:1" -> "lib:ext1"
+  "exe:proj/dune:0" -> "lib:lib1"
+  "exe:proj/dune:0" -> "lib:lib2"
+  "exe:proj/dune:0" -> "lib:lib3"
   "exe:proj/dune:3" -> "lib:lib4"
-  "exe:proj/dune:11" -> "lib:priv_lib1"
+  "exe:proj/dune:11" -> "lib:lib1"
   "exe:proj/dune:12" -> "lib:lib1-alt"
   "exe:proj/with-subdir/dune:2" -> "lib:foosubdirlib"
   "exe:proj/with-subdir/dune:0" -> "lib:foosubdirlib"
@@ -49,9 +48,9 @@ digraph {
   "lib:lib3" -> "lib:lib4"
   "lib:lib3" -> "lib:lib5"
   "lib:lib3" -> "lib:ext2"
-  "lib:lib4" -> "lib:priv_lib1"
+  "lib:lib4" -> "lib:lib1"
   "lib:lib4" -> "lib:ext3"
-  "lib:lib5" -> "lib:priv_lib1"
+  "lib:lib5" -> "lib:lib1"
   "lib:lib5" -> "lib:ext3"
-  "lib:more" -> "lib:priv_lib1"
+  "lib:more" -> "lib:lib1"
 }

--- a/test/proj.dot.expected
+++ b/test/proj.dot.expected
@@ -2,13 +2,13 @@ digraph {
   "exe:extra-proj/dune:0" [label="extra",shape=diamond]
   "exe:proj/bar/test/dune:0" [label="test<bar/test>",shape=diamond]
   "exe:proj/foo/test/dune:0" [label="test<foo/test>",shape=diamond]
-  "exe:proj/dune:11" [label="lib-or-exe",shape=diamond]
+  "exe:proj/dune:10" [label="lib-or-exe",shape=diamond]
   "exe:proj/dune:0" [label="prog1",shape=diamond]
   "exe:proj/dune:1" [label="prog2",shape=diamond]
   "exe:proj/dune:2" [label="prog3",shape=diamond]
   "exe:proj/dune:3" [label="prog4",shape=diamond]
+  "exe:proj/dune:11" [label="test<proj>",shape=diamond]
   "exe:proj/dune:12" [label="test<proj>",shape=diamond]
-  "exe:proj/dune:13" [label="test<proj>",shape=diamond]
   "exe:proj/with-subdir/dune:2" [label="barnotsubdir",shape=diamond]
   "exe:proj/with-subdir/dune:0" [label="foosubdir",shape=diamond]
   "lib:ext1" [label="ext1",style=filled]
@@ -17,7 +17,7 @@ digraph {
   "lib:foosubdirlib" [label="foosubdirlib"]
   "lib:foosubdirlib-dep" [label="foosubdirlib-dep",style=filled]
   "lib:lib-or-exe" [label="lib-or-exe"]
-  "lib:lib1" [label="lib1"]
+  "lib:lib1" [label="lib1",style=filled]
   "lib:lib1-alt" [label="lib1-alt",style=filled]
   "lib:lib2" [label="lib2"]
   "lib:lib3" [label="lib3"]
@@ -25,21 +25,21 @@ digraph {
   "lib:lib5" [label="lib5"]
   "lib:more" [label="more"]
   "lib:priv_lib1" [label="priv_lib1"]
-  "exe:proj/bar/test/dune:0" -> "lib:lib1"
-  "exe:proj/foo/test/dune:0" -> "lib:lib1"
-  "exe:proj/dune:11" -> "lib:lib-or-exe"
-  "exe:proj/dune:0" -> "lib:lib1"
+  "exe:proj/bar/test/dune:0" -> "lib:priv_lib1"
+  "exe:proj/foo/test/dune:0" -> "lib:priv_lib1"
+  "exe:proj/dune:10" -> "lib:lib-or-exe"
+  "exe:proj/dune:0" -> "lib:priv_lib1"
   "exe:proj/dune:0" -> "lib:lib2"
   "exe:proj/dune:0" -> "lib:lib3"
-  "exe:proj/dune:1" -> "lib:lib1"
+  "exe:proj/dune:1" -> "lib:priv_lib1"
   "exe:proj/dune:1" -> "lib:lib3"
   "exe:proj/dune:1" -> "lib:ext1"
-  "exe:proj/dune:2" -> "lib:lib1"
+  "exe:proj/dune:2" -> "lib:priv_lib1"
   "exe:proj/dune:2" -> "lib:lib3"
   "exe:proj/dune:2" -> "lib:ext1"
   "exe:proj/dune:3" -> "lib:lib4"
-  "exe:proj/dune:12" -> "lib:lib1"
-  "exe:proj/dune:13" -> "lib:lib1-alt"
+  "exe:proj/dune:11" -> "lib:priv_lib1"
+  "exe:proj/dune:12" -> "lib:lib1-alt"
   "exe:proj/with-subdir/dune:2" -> "lib:foosubdirlib"
   "exe:proj/with-subdir/dune:0" -> "lib:foosubdirlib"
   "lib:foosubdirlib" -> "lib:foosubdirlib-dep"
@@ -49,9 +49,9 @@ digraph {
   "lib:lib3" -> "lib:lib4"
   "lib:lib3" -> "lib:lib5"
   "lib:lib3" -> "lib:ext2"
-  "lib:lib4" -> "lib:lib1"
+  "lib:lib4" -> "lib:priv_lib1"
   "lib:lib4" -> "lib:ext3"
-  "lib:lib5" -> "lib:lib1"
+  "lib:lib5" -> "lib:priv_lib1"
   "lib:lib5" -> "lib:ext3"
-  "lib:more" -> "lib:lib1"
+  "lib:more" -> "lib:priv_lib1"
 }

--- a/test/proj/dune
+++ b/test/proj/dune
@@ -10,6 +10,7 @@
 
 (executables
   (names prog2 prog3)
+  (public_names pppprog2 pppppprog3)
   (libraries lib1 lib3 ext1)
 )
 

--- a/test/proj/dune
+++ b/test/proj/dune
@@ -45,7 +45,7 @@
 
 (executable
   (name test)
-  (libraries lib1)
+  (libraries priv_lib1)
 )
 
 ; Other executable with the same path. Don't know if that's even possible


### PR DESCRIPTION
This PR's main contribution is to keep track of public and non-public names. It translates all dependencies to non-public names into dependencies to corresponding public names. This is to avoid the same library appearing twice under different name in the graph.

There are other minor contributions. I'm happy to split those into separate PRs or drop them completely.